### PR TITLE
Add EscenasManager for scene management

### DIFF
--- a/Scripts/Globales/EscenasManager.gd
+++ b/Scripts/Globales/EscenasManager.gd
@@ -1,0 +1,15 @@
+extends Node
+
+func cambiar_escena(nombre : Escenas):
+	if DiccionarioDeEscenas.has(nombre):
+		get_tree().change_scene_to_file(DiccionarioDeEscenas[nombre] as String)
+	else:
+		print("[EscenasManager]: La escena %s no fue encontrada en el diccionario de escenas. Checa el script EscenasManager.gd" % nombre)
+
+enum Escenas {
+	Menu_Principal
+}
+
+const DiccionarioDeEscenas : Dictionary[Escenas, String] = {
+	Escenas.Menu_Principal: "res://Escenas/Menus/MenuPrincipal.tscn"
+}

--- a/Scripts/Globales/EscenasManager.gd.uid
+++ b/Scripts/Globales/EscenasManager.gd.uid
@@ -1,0 +1,1 @@
+uid://caqdggs02lcpl

--- a/project.godot
+++ b/project.godot
@@ -18,6 +18,7 @@ config/features=PackedStringArray("4.5", "Forward Plus")
 
 AudioManager="*res://Scripts/Globales/AudioManager.gd"
 DatosGlobales="*res://Scripts/Globales/DatosGlobales.gd"
+EscenasManager="*res://Scripts/Globales/EscenasManager.gd"
 
 [display]
 


### PR DESCRIPTION
Introduces EscenasManager.gd to handle scene changes using an enum and a dictionary mapping. Registers EscenasManager in project.godot for global access.